### PR TITLE
[FIX] portrait video appears stretched in video trimmer preview

### DIFF
--- a/android/src/main/java/com/videotrim/widgets/VideoTrimmerView.java
+++ b/android/src/main/java/com/videotrim/widgets/VideoTrimmerView.java
@@ -174,8 +174,9 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
     int screenHeight = mLinearVideo.getHeight();
 
     if (videoHeight > videoWidth) {
-      lp.width = screenWidth;
       lp.height = screenHeight;
+      float r = videoWidth / (float) videoHeight;
+      lp.width = (int) (lp.height * r);
     } else {
       lp.width = screenWidth;
       float r = videoHeight / (float) videoWidth;


### PR DESCRIPTION
When open portrait video  it appears stretched