### PR TITLE
Fix: Handle spaces in ffmpeg input file path

### DIFF
--- a/android/src/main/java/com/videotrim/utils/VideoTrimmerUtil.java
+++ b/android/src/main/java/com/videotrim/utils/VideoTrimmerUtil.java
@@ -48,7 +48,13 @@ public class VideoTrimmerUtil {
     // Format the current date and time
     String formattedDateTime = dateFormat.format(currentDate);
 
-    String cmd = "-ss " + startMs + "ms" + " -to " + endMs + "ms -i " + inputFile + " -c copy -metadata creation_time=" + formattedDateTime + " " + outputFile;
+    // Escape backslashes
+    inputFile = inputFile.replace("\\", "\\\\");
+
+    // Escape double quotes
+    inputFile = inputFile.replace("\"", "\\\"");
+
+    String cmd = "-ss " + startMs + "ms" + " -to " + endMs + "ms -i \"" + inputFile + "\" -c copy -metadata creation_time=" + formattedDateTime + " " + outputFile;
     callback.onStartTrim();
     FFmpegKit.executeAsync(cmd, session -> {
       SessionState state = session.getState();

--- a/ios/VideoTrim.swift
+++ b/ios/VideoTrim.swift
@@ -281,7 +281,13 @@ class VideoTrim: RCTEventEmitter {
         formatter.timeZone = TimeZone(identifier: "UTC")
         let dateTime = formatter.string(from: Date())
         
-        let cmd = "-ss \(startTime * 1000)ms -to \(endTime * 1000)ms -i \(inputFile) -c copy -metadata creation_time=\(dateTime) \(outputFile)";
+        // Escape backslashes
+        inputFile = inputFile.replacingOccurrences(of: "\\", with: "\\\\");
+
+        // Escape double quotes
+        inputFile = inputFile.replacingOccurrences(of: "\"", with: "\\\"");
+
+        let cmd = "-ss \(startTime * 1000)ms -to \(endTime * 1000)ms -i \"\(inputFile)\" -c copy -metadata creation_time=\(dateTime) \(outputFile)";
                 
         self.emitEventToJS("onStartTrimming", eventData: nil)
         


### PR DESCRIPTION
The ffmpeg command fails if the inputFile variable contains spaces because the spaces will be interpreted as argument separators by the command-line interpreter. To handle file paths with spaces, the path need to be properly escaped or quoted. The path is now single-quoted in both the Android VideoTrimmerUtil.java file and iOS VideoTrim.swift file.