### PR TITLE
feat: add drag strip to pan trim window

### DIFF
--- a/android/src/main/java/com/videotrim/widgets/VideoTrimmerView.java
+++ b/android/src/main/java/com/videotrim/widgets/VideoTrimmerView.java
@@ -130,6 +130,9 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
   private View currentSelectedhandle;
 
   private RelativeLayout trimmerView;
+  private FrameLayout dragStrip;
+  private float dragStripLastX = 0;
+  private boolean showDragStrip = true;
 
   private int trimmerColor = Color.parseColor(getContext().getString(R.string.trim_color)); // Default color if not set
   private int handleIconColor = Color.BLACK; // Default chevron color
@@ -187,6 +190,7 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
     headerText = findViewById(R.id.headerText);
 
     trimmerView = findViewById(R.id.trimmerView);
+    dragStrip = (FrameLayout) findViewById(R.id.dragStrip);
 
     leadingChevron = findViewById(R.id.leadingChevron);
     trailingChevron = findViewById(R.id.trailingChevron);
@@ -326,6 +330,12 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
 
     mOnTrimVideoListener.onLoad(mDuration);
     ignoreSystemGestureForView(trimmerView);
+    if (showDragStrip) {
+      ignoreSystemGestureForView(dragStrip);
+      setupDragStripVisual();
+    } else {
+      dragStrip.setVisibility(View.GONE);
+    }
   }
 
   private void updateGradientColors(int startColor, int endColor) {
@@ -353,6 +363,7 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
 
     updateTrimmerContainerWidth();
     updateCurrentTime(false);
+    updateDragStripPosition();
 
     trimmerContainerWrapper.setVisibility(View.VISIBLE);
     trimmerContainerWrapper.animate().alpha(1f).setDuration(250).start();
@@ -396,6 +407,7 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
     mPlayView.setOnClickListener(view -> playOrPause());
     setHandleTouchListener(leadingHandle, true);
     setHandleTouchListener(trailingHandle, false);
+    if (showDragStrip) setDragStripTouchListener();
   }
 
   public void onSaveClicked() {
@@ -532,6 +544,8 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
       Log.d(TAG, "Configured zoom on waiting duration: " + (zoomOnWaitingDuration / 1000.0) + " seconds");
     }
 
+    showDragStrip = !config.hasKey("enableDragStrip") || config.getBoolean("enableDragStrip");
+
     trimmerColor = config.hasKey("trimmerColor") ? config.getInt("trimmerColor") : Color.parseColor(getContext().getString(R.string.trim_color));
     handleIconColor = config.hasKey("handleIconColor") ? config.getInt("handleIconColor") : Color.BLACK;
 
@@ -660,6 +674,81 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
     int seconds = totalSeconds % 60;
     int millis = milliseconds % 1000;
     return String.format(Locale.getDefault(), "%d:%02d.%03d", minutes, seconds, millis);
+  }
+
+  private void updateDragStripPosition() {
+    if (!showDragStrip || dragStrip == null || leadingHandle == null || trailingHandle == null) return;
+    // Use handle positions directly — they're already in trimmerView's coordinate space
+    float selectionLeft = leadingHandle.getX() + leadingHandle.getWidth();
+    float selectionRight = trailingHandle.getX();
+    float midX = trimmerView.getX() + (selectionLeft + selectionRight) / 2f;
+    dragStrip.setX(midX - dragStrip.getWidth() / 2f);
+  }
+
+  private void setupDragStripVisual() {
+    GradientDrawable bg = new GradientDrawable();
+    bg.setShape(GradientDrawable.RECTANGLE);
+    bg.setColor(0x14FFFFFF); // 8% white
+    bg.setCornerRadius(dpToPx(6));
+    dragStrip.setBackground(bg);
+
+    // Three vertical bars (|||) centered inside the drag strip
+    android.widget.LinearLayout bars = new android.widget.LinearLayout(getContext());
+    bars.setOrientation(android.widget.LinearLayout.HORIZONTAL);
+    bars.setGravity(android.view.Gravity.CENTER);
+    FrameLayout.LayoutParams barsParams = new FrameLayout.LayoutParams(
+      android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+      android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+    );
+    barsParams.gravity = android.view.Gravity.CENTER;
+    for (int i = 0; i < 3; i++) {
+      android.view.View bar = new android.view.View(getContext());
+      GradientDrawable barBg = new GradientDrawable();
+      barBg.setShape(GradientDrawable.RECTANGLE);
+      barBg.setColor(0x80FFFFFF); // 50% white
+      barBg.setCornerRadius(dpToPx(1));
+      bar.setBackground(barBg);
+      android.widget.LinearLayout.LayoutParams barParams = new android.widget.LinearLayout.LayoutParams(dpToPx(2), dpToPx(16));
+      barParams.setMargins(dpToPx(3), 0, dpToPx(3), 0);
+      bars.addView(bar, barParams);
+    }
+    dragStrip.addView(bars, barsParams);
+  }
+
+  private void setDragStripTouchListener() {
+    dragStrip.setOnTouchListener((view, event) -> {
+      switch (event.getAction()) {
+        case MotionEvent.ACTION_DOWN:
+          dragStripLastX = event.getRawX();
+          onMediaPause();
+          playHapticFeedback(true);
+          break;
+        case MotionEvent.ACTION_MOVE: {
+          float delta = event.getRawX() - dragStripLastX;
+          dragStripLastX = event.getRawX();
+          if (trimmerContainerBg.getWidth() <= 0 || mDuration <= 0) break;
+          long clipDuration = endTime - startTime;
+          long timeDelta = (long) ((delta / (float) trimmerContainerBg.getWidth()) * mDuration);
+          long newStart = startTime + timeDelta;
+          newStart = Math.max(0, Math.min(newStart, mDuration - clipDuration));
+          startTime = newStart;
+          endTime = newStart + clipDuration;
+          updateHandlePositions();
+          seekTo(startTime, true);
+          break;
+        }
+        case MotionEvent.ACTION_UP:
+          view.performClick();
+          break;
+        default:
+          return false;
+      }
+      return true;
+    });
+  }
+
+  public void setShowDragStrip(boolean show) {
+    this.showDragStrip = show;
   }
 
   private void setProgressIndicatorTouchListener() {
@@ -877,6 +966,7 @@ public class VideoTrimmerView extends FrameLayout implements IVideoTrimmerView {
           didClampWhilePanning = didClamp;
 
           updateTrimmerContainerWidth();
+          updateDragStripPosition();
           seekTo(isLeading ? startTime : endTime, false);
 
           // Start zoom wait timer when dragging handles

--- a/android/src/main/res/layout/video_trimmer_view.xml
+++ b/android/src/main/res/layout/video_trimmer_view.xml
@@ -167,10 +167,20 @@
     </RelativeLayout>
 
     <FrameLayout
+      android:id="@+id/dragStrip"
+      android:layout_width="60dp"
+      android:layout_height="28dp"
+      android:layout_below="@+id/trimmerView"
+      android:layout_centerHorizontal="true"
+      android:background="@android:color/transparent"
+      android:clickable="true"
+      android:focusable="true" />
+
+    <FrameLayout
       android:id="@+id/timingStackView"
       android:layout_width="match_parent"
       android:layout_height="50dp"
-      android:layout_below="@+id/trimmerView"
+      android:layout_below="@+id/dragStrip"
       android:layout_marginHorizontal="16dp"
       android:orientation="horizontal"
       android:visibility="visible">

--- a/ios/VideoTrimmerViewController.swift
+++ b/ios/VideoTrimmerViewController.swift
@@ -181,6 +181,11 @@ class VideoTrimmerViewController: UIViewController {
         setupDragStrip()
     }
     
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updateDragStripPosition()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
@@ -522,8 +527,11 @@ class VideoTrimmerViewController: UIViewController {
         guard totalDuration > 0 else { return }
         let midSeconds = (trimmer.selectedRange.start.seconds + trimmer.selectedRange.end.seconds) / 2.0
         let fraction = midSeconds / totalDuration
-        let availableWidth = trimmer.bounds.width - trimmer.horizontalInset * 2
-        let midOffsetInTrimmer = trimmer.horizontalInset + availableWidth * CGFloat(fraction)
+        // Mirror VideoTrimmer's locationForTime: totalInset = chevronWidth(16) + horizontalInset(16)
+        let chevronWidth: CGFloat = 16
+        let totalInset = trimmer.horizontalInset + chevronWidth
+        let availableWidth = trimmer.bounds.width - totalInset * 2
+        let midOffsetInTrimmer = totalInset + availableWidth * CGFloat(fraction)
         let midX = trimmer.frame.minX + midOffsetInTrimmer
         dragStripCenterXConstraint.constant = midX - view.bounds.width / 2
     }
@@ -541,7 +549,8 @@ class VideoTrimmerViewController: UIViewController {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
             }
         case .changed:
-            let availableWidth = trimmer.bounds.width - trimmer.horizontalInset * 2
+            let chevronWidth: CGFloat = 16
+            let availableWidth = trimmer.bounds.width - (trimmer.horizontalInset + chevronWidth) * 2
             guard availableWidth > 0 else { return }
             let totalSeconds = asset.duration.seconds
             let timeDeltaSeconds = Double(translation.x) / Double(availableWidth) * totalSeconds

--- a/ios/VideoTrimmerViewController.swift
+++ b/ios/VideoTrimmerViewController.swift
@@ -48,6 +48,9 @@ class VideoTrimmerViewController: UIViewController {
     var saveBtnClicked: ((CMTimeRange) -> Void)?
     private var enableHapticFeedback = true
     private var zoomOnWaitingDuration: Double = 5.0 // Default: 5 seconds
+    private var enableDragStrip = true
+    private var dragStripView: UIView!
+    private var dragStripCenterXConstraint: NSLayoutConstraint!
     
     // New color properties
     private var trimmerColor: UIColor = UIColor.systemYellow
@@ -148,6 +151,7 @@ class VideoTrimmerViewController: UIViewController {
         leadingTrimLabel.text = trimmer.selectedRange.start.displayString
         currentTimeLabel.text = trimmer.progress.displayString
         trailingTrimLabel.text = trimmer.selectedRange.end.displayString
+        updateDragStripPosition()
     }
     
     private func handleBeforeProgressChange() {
@@ -174,6 +178,7 @@ class VideoTrimmerViewController: UIViewController {
         setupView()
         setupButtons()
         setupTimeLabels()
+        setupDragStrip()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -360,7 +365,7 @@ class VideoTrimmerViewController: UIViewController {
         NSLayoutConstraint.activate([
             trimmer.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             trimmer.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            trimmer.bottomAnchor.constraint(equalTo: timingStackView.topAnchor, constant: -16),
+            trimmer.bottomAnchor.constraint(equalTo: dragStripView.topAnchor, constant: -4),
             trimmer.heightAnchor.constraint(equalToConstant: 50)
         ])
         
@@ -466,6 +471,94 @@ class VideoTrimmerViewController: UIViewController {
         }
     }
     
+    private func setupDragStrip() {
+        dragStripView = UIView()
+        dragStripView.translatesAutoresizingMaskIntoConstraints = false
+        dragStripView.backgroundColor = UIColor(white: 1, alpha: 0.08)
+        dragStripView.layer.cornerRadius = 6
+
+        // Three vertical bars icon (|||)
+        let barsContainer = UIView()
+        barsContainer.translatesAutoresizingMaskIntoConstraints = false
+        dragStripView.addSubview(barsContainer)
+        NSLayoutConstraint.activate([
+            barsContainer.centerXAnchor.constraint(equalTo: dragStripView.centerXAnchor),
+            barsContainer.centerYAnchor.constraint(equalTo: dragStripView.centerYAnchor),
+            barsContainer.widthAnchor.constraint(equalToConstant: 22),
+            barsContainer.heightAnchor.constraint(equalToConstant: 16),
+        ])
+        for i in 0..<3 {
+            let bar = UIView()
+            bar.translatesAutoresizingMaskIntoConstraints = false
+            bar.backgroundColor = UIColor(white: 1, alpha: 0.5)
+            bar.layer.cornerRadius = 1
+            barsContainer.addSubview(bar)
+            NSLayoutConstraint.activate([
+                bar.widthAnchor.constraint(equalToConstant: 2),
+                bar.heightAnchor.constraint(equalToConstant: 16),
+                bar.topAnchor.constraint(equalTo: barsContainer.topAnchor),
+                bar.leadingAnchor.constraint(equalTo: barsContainer.leadingAnchor, constant: CGFloat(i) * 10),
+            ])
+        }
+
+        view.addSubview(dragStripView)
+        dragStripCenterXConstraint = dragStripView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        NSLayoutConstraint.activate([
+            dragStripView.widthAnchor.constraint(equalToConstant: 60),
+            dragStripView.heightAnchor.constraint(equalToConstant: 28),
+            dragStripView.bottomAnchor.constraint(equalTo: timingStackView.topAnchor, constant: -4),
+            dragStripCenterXConstraint,
+        ])
+
+        let pan = UIPanGestureRecognizer(target: self, action: #selector(dragStripPanned(_:)))
+        dragStripView.addGestureRecognizer(pan)
+        dragStripView.isHidden = !enableDragStrip
+    }
+
+    private func updateDragStripPosition() {
+        guard enableDragStrip, let _ = asset, let trimmer = trimmer,
+              trimmer.bounds.width > 0 else { return }
+        let totalDuration = asset!.duration.seconds
+        guard totalDuration > 0 else { return }
+        let midSeconds = (trimmer.selectedRange.start.seconds + trimmer.selectedRange.end.seconds) / 2.0
+        let fraction = midSeconds / totalDuration
+        let availableWidth = trimmer.bounds.width - trimmer.horizontalInset * 2
+        let midOffsetInTrimmer = trimmer.horizontalInset + availableWidth * CGFloat(fraction)
+        let midX = trimmer.frame.minX + midOffsetInTrimmer
+        dragStripCenterXConstraint.constant = midX - view.bounds.width / 2
+    }
+
+    @objc private func dragStripPanned(_ gesture: UIPanGestureRecognizer) {
+        guard let asset = asset, let trimmer = trimmer else { return }
+        let translation = gesture.translation(in: dragStripView)
+        gesture.setTranslation(.zero, in: dragStripView)
+
+        switch gesture.state {
+        case .began:
+            player.pause()
+            setPlayBtnIcon()
+            if enableHapticFeedback {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            }
+        case .changed:
+            let availableWidth = trimmer.bounds.width - trimmer.horizontalInset * 2
+            guard availableWidth > 0 else { return }
+            let totalSeconds = asset.duration.seconds
+            let timeDeltaSeconds = Double(translation.x) / Double(availableWidth) * totalSeconds
+            let timeDelta = CMTime(seconds: timeDeltaSeconds, preferredTimescale: 600)
+            let clipDuration = trimmer.selectedRange.duration
+            var newStart = CMTimeAdd(trimmer.selectedRange.start, timeDelta)
+            newStart = CMTimeMaximum(newStart, .zero)
+            let maxStart = CMTimeSubtract(asset.duration, clipDuration)
+            newStart = CMTimeMinimum(newStart, CMTimeMaximum(maxStart, .zero))
+            trimmer.selectedRange = CMTimeRange(start: newStart, duration: clipDuration)
+            updateLabels()
+            seek(to: newStart)
+        default:
+            break
+        }
+    }
+
   public func configure(config: NSDictionary) {
     if let maxDuration = config["maxDuration"] as? Int, maxDuration > 0 {
       maximumDuration = maxDuration
@@ -480,6 +573,7 @@ class VideoTrimmerViewController: UIViewController {
     jumpToPositionOnLoad = config["jumpToPositionOnLoad"] as? Double ?? 0
     enableHapticFeedback = config["enableHapticFeedback"] as? Bool ?? true
     zoomOnWaitingDuration = (config["zoomOnWaitingDuration"] as? Double ?? 5.0) / 1000.0 // convert ms to s
+    enableDragStrip = config["enableDragStrip"] as? Bool ?? true
     autoplay = config["autoplay"] as? Bool ?? false
     headerText = config["headerText"] as? String
     headerTextSize = config["headerTextSize"] as? Int ?? 16

--- a/src/NativeVideoTrim.ts
+++ b/src/NativeVideoTrim.ts
@@ -118,6 +118,12 @@ export interface EditorConfig extends BaseOptions {
    * this duration around the current trim position for more precise editing.
    */
   zoomOnWaitingDuration?: number;
+  /**
+   * Whether to show the drag strip handle below the trimmer bar (default: `true`).
+   * The drag strip lets users pan the entire trim window left/right while keeping
+   * the clip duration fixed.
+   */
+  enableDragStrip?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a small draggable `|||` handle below the trimmer bar on both iOS and Android
- Dragging the handle pans the entire trim selection window left/right while keeping clip duration fixed
- The handle tracks the center of the current selection as the trim handles are moved
- Player seeks to the new start time during pan so the preview updates in real time
- Haptic feedback on drag start (both platforms)
- New `enableDragStrip` config option (default: `true`) to hide it if not needed

## Changes

| File | Change |
|------|--------|
| `src/NativeVideoTrim.ts` | Added `enableDragStrip?: boolean` to `EditorConfig` |
| `ios/VideoTrimmerViewController.swift` | `setupDragStrip()`, `updateDragStripPosition()`, `dragStripPanned(_:)` |
| `android/.../VideoTrimmerView.java` | `setupDragStripVisual()`, `updateDragStripPosition()`, `setDragStripTouchListener()` |
| `android/.../video_trimmer_view.xml` | Added `dragStrip` FrameLayout between trimmer and timing labels |

## Test plan

- [ ] iOS: drag strip appears below trimmer, centered on selection
- [ ] iOS: dragging the `|||` handle pans both handles together
- [ ] Android: same behaviour as iOS
- [ ] Both: dragging a trim handle updates the drag strip position
- [ ] Both: `enableDragStrip: false` hides the strip
- [ ] Both: player preview updates during pan (not just on release)
- [ ] Both: panning clamps correctly at video start/end boundaries

## Demos

<table>
  <tr>
    <th>Android</th>
    <th>iOS</th>
  </tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/c244a86f-89a4-4258-9928-389aa3d4f9ed" width="300"></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/e8f94f15-f901-4ad1-94c1-d3c1bb361100" width="300"></video>
    </td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)