### PR TITLE
fix(ios): autorotate so rotation-tagged portrait clips don't trim sideways (double rotation)

### DIFF
--- a/ios/VideoTrim.swift
+++ b/ios/VideoTrim.swift
@@ -382,22 +382,13 @@ public class VideoTrim: RCTEventEmitter, AssetLoaderDelegate, UIDocumentPickerDe
     let needsReEncode = hasUserTransform || cropNorm != nil || enablePreciseTrimming || needsSpeed
     
     if needsReEncode, let vc = vc {
-      // -noautorotate disables FFmpeg's automatic rotation, so we must manually
-      // compensate for the source video's rotation metadata via transpose filters.
-      if let asset = vc.asset,
-         let videoTrack = asset.tracks(withMediaType: .video).first {
-        let t = videoTrack.preferredTransform
-        let sourceAngle = atan2(t.b, t.a)
-        if abs(sourceAngle - .pi / 2) < 0.1 {
-          videoFilters.append("transpose=1")
-        } else if abs(sourceAngle + .pi / 2) < 0.1 {
-          videoFilters.append("transpose=2")
-        } else if abs(abs(sourceAngle) - .pi) < 0.1 {
-          videoFilters.append("transpose=1")
-          videoFilters.append("transpose=1")
-        }
-      }
-      
+      // Let FFmpeg autorotate the source (note: NO -noautorotate below). Autorotate bakes
+      // the source rotation matrix into upright, display-orientation pixels AND strips the
+      // matrix from the output. The previous approach (-noautorotate + a manual source-
+      // compensation transpose) baked the pixels but left the source rotation matrix on the
+      // output, so on ffmpeg-kit 6 every rotation-tagged portrait clip came out
+      // double-rotated (sideways). User rotate/flip and crop below operate on the already-
+      // upright autorotated frame, so their math is unchanged.
       switch vc.rotationCount {
       case 1: videoFilters.append("transpose=2")
       case 2:
@@ -464,9 +455,9 @@ public class VideoTrim: RCTEventEmitter, AssetLoaderDelegate, UIDocumentPickerDe
         }
       }
       
-      // -noautorotate: we handle rotation via explicit transpose filters above,
-      // so FFmpeg must not auto-rotate or the output will be double-rotated.
-      cmds.append("-noautorotate")
+      // NOTE: intentionally NO -noautorotate. FFmpeg autorotates the input so the source
+      // rotation is baked into the pixels and the output carries no stale rotation matrix
+      // (otherwise rotation-tagged portrait clips are double-rotated -> sideways on ffmpeg-kit 6).
       cmds.append(contentsOf: ["-i", inputFile.path])
       // When enablePreciseTrimming is the only reason for re-encode (no transforms),
       // videoFilters is empty — skip -vf entirely to avoid FFmpeg error on empty filter.


### PR DESCRIPTION
Fixes #133.

## Problem

Trimming/re-encoding a **portrait video with a rotation matrix** (coded-landscape buffer + 90° display matrix — the standard iPhone layout) produces **sideways** output. Landscape clips are fine.

The iOS re-encode path uses `-noautorotate` + a manual source-compensation `transpose` to bake the source rotation into the pixels, but it **never strips the source's display matrix from the output**. On **ffmpeg-kit 6** that matrix is propagated, so the output has upright portrait pixels **and** a stale 90° matrix → players rotate it again → sideways.

`ffprobe` of input vs. old output:

```
input :  coded 1920x1080  rotation=90   -> 1080x1920 portrait (correct)
output:  coded 1080x1920  rotation=90   -> rotated AGAIN -> sideways   ← bug
```

(`-metadata:s:v:0 rotate=0` does **not** fix it — that only sets the legacy `rotate` tag, not the Display Matrix side-data AVFoundation reads.)

## Fix

Remove `-noautorotate` and the manual source-compensation `transpose`, and let **FFmpeg autorotate** the input. Autorotate bakes the source rotation into upright, display-orientation pixels **and strips the matrix** from the output. User `rotate`/`flip`/`crop` already run after this point in the filter chain, so they now compose on the already-upright frame and their math is unchanged.

Net: `-19 / +10` lines (the manual rotation block is replaced by relying on autorotate).

## How I tested

Patched a real app's iOS dev client (ffmpeg-kit 6) and re-ran a full fixture matrix on the iOS Simulator, probing every output with `ffprobe` + visual checks. Also reproduced the bug and validated the fix in isolation on **ffmpeg 6.1.5** (`-noautorotate -i in -vf transpose=1 ...` keeps `rotation=90`; plain autorotate yields no rotation side-data).

| edit | source | output |
|---|---|---|
| trim | portrait 1080p/4K, H.264/HEVC, 30/60 | ✅ upright `1080x1920` / `2160x3840`, **no rotation tag** |
| trim | landscape 1080p/4K | ✅ unchanged, correct |
| crop | portrait | ✅ `792x1920` upright (cropped horizontally) |
| rotate | portrait → 90° | ✅ `1920x1080`, no stale tag |
| flip | portrait | ✅ upright, mirrored |
| mute | clip w/ AAC | ✅ audio stream removed |
| speed 2x | 4K clip | ✅ duration halved, upright |

Codec → H.264, fps/resolution preserved throughout. No double-rotation anywhere.